### PR TITLE
Move to gtk2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.flatpak-builder
+build-dir
+

--- a/org.geeqie.Geeqie.json
+++ b/org.geeqie.Geeqie.json
@@ -89,6 +89,7 @@
             ]
         },
         "shared-modules/intltool/intltool-0.51.json",
+        "shared-modules/gtk2/gtk2.json",
         {
             "name": "geeqie",
             "config-opts": [
@@ -96,13 +97,12 @@
                 "--disable-lua",
                 "--disable-gpu-accel",
                 "--disable-ffmpegthumbnailer",
-                "--enable-gtk3"
+                "--disable-gtk3"
             ],
             "cleanup": [
                 "/share/man"
             ],
             "post-install": [
-                "install -Dm644 org.geeqie.Geeqie.appdata.xml /app/share/metainfo/org.geeqie.Geeqie.appdata.xml",
                 "install -Dm644 src/icons/svg/gqview_icon.svg /app/share/icons/hicolor/scalable/apps/geeqie.svg",
                 "rm -r /app/share/pixmaps"
             ],

--- a/org.geeqie.Geeqie.json
+++ b/org.geeqie.Geeqie.json
@@ -103,7 +103,7 @@
             ],
             "post-install": [
                 "install -Dm644 org.geeqie.Geeqie.appdata.xml /app/share/metainfo/org.geeqie.Geeqie.appdata.xml",
-                "install -Dm644 /app/share/pixmaps/geeqie.png /app/share/icons/hicolor/48x48/apps/geeqie.png",
+                "install -Dm644 src/icons/svg/gqview_icon.svg /app/share/icons/hicolor/scalable/apps/geeqie.svg",
                 "rm -r /app/share/pixmaps"
             ],
             "sources": [


### PR DESCRIPTION
This is done, because GTK3 is quite buggy.
GTK3 is marked experimental by the developers (see http://www.geeqie.org/installing.html).