### PR TITLE
Update to GTK3 build with clutter and Gnome 42 [Testing]

### DIFF
--- a/org.geeqie.Geeqie.json
+++ b/org.geeqie.Geeqie.json
@@ -108,8 +108,7 @@
                 "/share/man"
             ],
             "post-install": [
-                "install -Dm644 org.geeqie.Geeqie.appdata.xml /app/share/metainfo/org.geeqie.Geeqie.appdata.xml",
-                "install -Dm644 /app/share/pixmaps/geeqie.png /app/share/icons/hicolor/48x48/apps/geeqie.png",
+                 "install -Dm644 src/icons/svg/gqview_icon.svg /app/share/icons/hicolor/scalable/apps/geeqie.svg",
                 "rm -r /app/share/pixmaps"
             ],
             "sources": [

--- a/org.geeqie.Geeqie.json
+++ b/org.geeqie.Geeqie.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.geeqie.Geeqie",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "41",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "command": "geeqie",
     "rename-desktop-file": "geeqie.desktop",
@@ -32,7 +32,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://exiv2.org/builds/exiv2-0.27.5-Source.tar.gz",
+                    "url": "https://github.com/Exiv2/exiv2/releases/download/v0.27.5/exiv2-0.27.5-Source.tar.gz",
                     "sha256": "35a58618ab236a901ca4928b0ad8b31007ebdc0386d904409d825024e45ea6e2"
                 }
             ]
@@ -54,6 +54,7 @@
                 }
             ]
         },
+        "shared-modules/clutter/clutter.json",
         {
             "name": "libchamplain",
             "sources": [
@@ -94,7 +95,6 @@
             ]
         },
         "shared-modules/intltool/intltool-0.51.json",
-        "shared-modules/gtk2/gtk2.json",
         {
             "name": "geeqie",
             "config-opts": [
@@ -102,13 +102,14 @@
                 "--disable-lua",
                 "--disable-gpu-accel",
                 "--disable-ffmpegthumbnailer",
-                "--disable-gtk3"
+                "--enable-gtk3"
             ],
             "cleanup": [
                 "/share/man"
             ],
             "post-install": [
-                "install -Dm644 src/icons/svg/gqview_icon.svg /app/share/icons/hicolor/scalable/apps/geeqie.svg",
+                "install -Dm644 org.geeqie.Geeqie.appdata.xml /app/share/metainfo/org.geeqie.Geeqie.appdata.xml",
+                "install -Dm644 /app/share/pixmaps/geeqie.png /app/share/icons/hicolor/48x48/apps/geeqie.png",
                 "rm -r /app/share/pixmaps"
             ],
             "sources": [

--- a/org.geeqie.Geeqie.json
+++ b/org.geeqie.Geeqie.json
@@ -108,7 +108,7 @@
                 "/share/man"
             ],
             "post-install": [
-                 "install -Dm644 src/icons/svg/gqview_icon.svg /app/share/icons/hicolor/scalable/apps/geeqie.svg",
+                "install -Dm644 src/icons/svg/gqview_icon.svg /app/share/icons/hicolor/scalable/apps/geeqie.svg",
                 "rm -r /app/share/pixmaps"
             ],
             "sources": [


### PR DESCRIPTION
Here is my first effort of a build for GTK3. I have tested only briefly and it looks ok, but it would be worth checking the errors that led to GTK3 being removed are gone.

I updated to Gnome 42, perhaps that was premature.

I had to update the shared-modules to get access to the clutter library needed by libchamplain. Added the clutter library to the build.

Fixes #16