### PR TITLE
Test: Use the lcms2 module from the runtime

### DIFF
--- a/org.geeqie.Geeqie.json
+++ b/org.geeqie.Geeqie.json
@@ -36,23 +36,6 @@
                 }
             ]
         },
-        {
-            "name": "lcms2",
-            "config-opts": [
-                "--disable-static"
-            ],
-            "cleanup": [
-                "/bin",
-                "/share"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.sourceforge.net/lcms/lcms2-2.8.tar.gz",
-                    "sha256": "66d02b229d2ea9474e62c2b6cd6720fde946155cd1d0d2bffdab829790a0fb22"
-                }
-            ]
-        },
         "shared-modules/intltool/intltool-0.51.json",
         {
             "name": "xxd",


### PR DESCRIPTION
GNOME runtime version 48 (based on Freedesktop runtime version 24.08) provides the lcms2 module.

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration. 

Fixes: https://github.com/flathub/org.geeqie.Geeqie/issues/43